### PR TITLE
Add TestSuite support to TaskDefinition

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -15,6 +15,12 @@ class Program:
     status: str = "unevaluated"
     created_at: float = field(default_factory=lambda: time.time())  # Track program age
 
+
+@dataclass
+class TestSuite:
+    """Collection of test cases for a task."""
+    tests: List[Dict[str, Any]] = field(default_factory=list)
+
 @dataclass
 class TaskDefinition:
     id: str
@@ -23,7 +29,8 @@ class TaskDefinition:
     input_output_examples: Optional[List[Dict[str, Any]]] = None                                                    
     evaluation_criteria: Optional[Dict[str, Any]] = None                                                            
     initial_code_prompt: Optional[str] = "Provide an initial Python solution for the following problem:"
-    allowed_imports: Optional[List[str]] = None                                  
+    allowed_imports: Optional[List[str]] = None
+    test_suite: TestSuite | None = None
 
 class BaseAgent(ABC):
     """Base class for all agents."""

--- a/tests/test_task_definition.py
+++ b/tests/test_task_definition.py
@@ -1,0 +1,16 @@
+import pytest
+from core.interfaces import TaskDefinition, TestSuite
+
+
+def test_task_definition_defaults():
+    task = TaskDefinition(id="t1", description="desc")
+    assert task.test_suite is None
+    assert task.input_output_examples is None
+    assert task.evaluation_criteria is None
+
+
+def test_task_definition_with_test_suite():
+    suite = TestSuite(tests=[{"input": 1, "output": 2}])
+    task = TaskDefinition(id="t2", description="desc", test_suite=suite)
+    assert task.test_suite is suite
+    assert task.test_suite.tests[0]["input"] == 1


### PR DESCRIPTION
## Summary
- add `TestSuite` dataclass
- support optional `test_suite` attribute on `TaskDefinition`
- add tests for dataclass creation

## Testing
- `pytest -q` *(fails: command not found)*