### PR TITLE
Add interactive test generator prototype

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -23,7 +23,11 @@ class TaskDefinition:
     input_output_examples: Optional[List[Dict[str, Any]]] = None                                                    
     evaluation_criteria: Optional[Dict[str, Any]] = None                                                            
     initial_code_prompt: Optional[str] = "Provide an initial Python solution for the following problem:"
-    allowed_imports: Optional[List[str]] = None                                  
+    allowed_imports: Optional[List[str]] = None
+
+    # Frozen set of tests for evaluating candidate programs. Populated after
+    # user approval in prototype_on_demand.
+    test_suite: Optional[str] = None
 
 class BaseAgent(ABC):
     """Base class for all agents."""

--- a/prototype_on_demand.py
+++ b/prototype_on_demand.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import subprocess
+import tempfile
+from typing import Callable, Optional
+
+from core.interfaces import TaskDefinition
+from task_manager.agent import TaskManagerAgent
+from test_generator.agent import TestGeneratorAgent
+
+
+def edit_text_in_editor(text: str) -> str:
+    """Open text in the user's editor and return the modified contents."""
+    editor = os.environ.get("EDITOR", "nano")
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".py") as f:
+        f.write(text)
+        f.flush()
+        tmp_path = f.name
+    subprocess.call([editor, tmp_path])
+    with open(tmp_path, "r") as f:
+        new_text = f.read()
+    os.unlink(tmp_path)
+    return new_text
+
+
+async def generate_and_confirm_tests(
+    task: TaskDefinition,
+    input_func: Callable[[str], str] = input,
+    edit_func: Callable[[str], str] = edit_text_in_editor,
+    test_agent: Optional[TestGeneratorAgent] = None,
+) -> Optional[TaskDefinition]:
+    """Interactively generate tests until user approval."""
+    agent = test_agent or TestGeneratorAgent()
+    tests, explanation = await agent.generate_tests(task)
+
+    while True:
+        print("\n=== Proposed Tests ===")
+        print(tests)
+        print("\n=== Explanation ===")
+        print(explanation)
+        cmd = input_func("[a]pprove/[r]egenerate/[e]dit/[q]uit: ").strip().lower()
+        if cmd == "a":
+            task.test_suite = tests
+            return task
+        elif cmd == "r":
+            tests, explanation = await agent.generate_tests(task)
+            continue
+        elif cmd == "e":
+            tests = edit_func(tests)
+            continue
+        elif cmd == "q":
+            print("Aborted by user.")
+            return None
+        else:
+            print("Invalid command. Please enter a, r, e, or q.")
+
+
+async def main():
+    task = TaskDefinition(
+        id="demo_task",
+        description="Return the same integer that is given as input.",
+        function_name_to_evolve="identity",
+    )
+
+    result = await generate_and_confirm_tests(task)
+    if not result:
+        return
+
+    manager = TaskManagerAgent(task_definition=result)
+    await manager.execute()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_generator/agent.py
+++ b/test_generator/agent.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Optional, Dict, Any, Tuple
+
+from core.interfaces import BaseAgent, TaskDefinition
+
+logger = logging.getLogger(__name__)
+
+class TestGeneratorAgent(BaseAgent):
+    """Simple agent that generates tests for a task. Placeholder implementation."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        super().__init__(config)
+        logger.info("TestGeneratorAgent initialized")
+
+    async def generate_tests(self, task: TaskDefinition) -> Tuple[str, str]:
+        """Return a tuple of (tests_code, explanation)."""
+        function_name = task.function_name_to_evolve or "solve"
+        tests = (
+            f"def test_example():\n"
+            f"    assert {function_name}(1) == 1\n"
+        )
+        explanation = "Basic placeholder test suite generated."
+        return tests, explanation
+
+    async def execute(self, task: TaskDefinition) -> Tuple[str, str]:
+        return await self.generate_tests(task)

--- a/tests/test_prototype_on_demand.py
+++ b/tests/test_prototype_on_demand.py
@@ -1,0 +1,86 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from core.interfaces import TaskDefinition
+from prototype_on_demand import generate_and_confirm_tests
+
+
+class PrototypeLoopTests(unittest.TestCase):
+    def test_approve_first_try(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("tests1", "exp1")
+
+        inputs = iter(["a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertIs(result, task)
+        self.assertEqual(task.test_suite, "tests1")
+        mock_agent.generate_tests.assert_awaited_once()
+
+    def test_regenerate_then_approve(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.side_effect = [("t1", "e1"), ("t2", "e2")]
+
+        inputs = iter(["r", "a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertEqual(task.test_suite, "t2")
+        self.assertEqual(mock_agent.generate_tests.await_count, 2)
+        self.assertIs(result, task)
+
+    def test_edit_then_approve(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("t1", "e1")
+
+        inputs = iter(["e", "a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: "edited",
+            )
+        )
+
+        self.assertEqual(task.test_suite, "edited")
+        self.assertIs(result, task)
+
+    def test_abort(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("t1", "e1")
+
+        inputs = iter(["q"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertIsNone(result)
+        self.assertIsNone(task.test_suite)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a simple `TestGeneratorAgent`
- implement `prototype_on_demand.py` for interactive test generation
- support storing approved tests in `TaskDefinition`
- basic unit tests covering approval loop

## Testing
- `python -m unittest discover -s tests -v`