### PR TITLE
Add interactive test generator prototype

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -23,7 +23,24 @@ class TaskDefinition:
     input_output_examples: Optional[List[Dict[str, Any]]] = None                                                    
     evaluation_criteria: Optional[Dict[str, Any]] = None                                                            
     initial_code_prompt: Optional[str] = "Provide an initial Python solution for the following problem:"
-    allowed_imports: Optional[List[str]] = None                                  
+    allowed_imports: Optional[List[str]] = None
+
+    # Frozen set of tests for evaluating candidate programs. Populated after
+    # user approval in prototype_on_demand.
+    test_suite: Optional[str] = None
+
+
+@dataclass
+class TestCase:
+    input: Any
+    output: Any
+
+
+@dataclass
+class TestSuite:
+    explanation: str
+    cases: List[Dict[str, Any]] = field(default_factory=list)
+    raw: Optional[str] = None
 
 class BaseAgent(ABC):
     """Base class for all agents."""

--- a/prototype_on_demand.py
+++ b/prototype_on_demand.py
@@ -1,0 +1,114 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Callable, Optional
+
+from core.interfaces import TaskDefinition
+from config import settings
+from test_generator.agent import TestGeneratorAgent
+from task_manager.agent import TaskManagerAgent
+
+logging.basicConfig(
+    level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
+    format=settings.LOG_FORMAT,
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler(settings.LOG_FILE, mode="a")
+    ],
+)
+logger = logging.getLogger(__name__)
+
+
+def edit_text_in_editor(text: str) -> str:
+    """Open text in the user's editor and return the modified contents."""
+    editor = os.environ.get("EDITOR", "nano")
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".py") as f:
+        f.write(text)
+        f.flush()
+        tmp_path = f.name
+    subprocess.call([editor, tmp_path])
+    with open(tmp_path, "r") as f:
+        new_text = f.read()
+    os.unlink(tmp_path)
+    return new_text
+
+
+async def generate_and_confirm_tests(
+    task: TaskDefinition,
+    input_func: Callable[[str], str] = input,
+    edit_func: Callable[[str], str] = edit_text_in_editor,
+    test_agent: Optional[TestGeneratorAgent] = None,
+) -> Optional[TaskDefinition]:
+    """Interactively generate tests until user approval."""
+    agent = test_agent or TestGeneratorAgent()
+    tests, explanation = await agent.generate_tests(task)
+
+    while True:
+        print("\n=== Proposed Tests ===")
+        print(tests)
+        print("\n=== Explanation ===")
+        print(explanation)
+        cmd = input_func("[a]pprove/[r]egenerate/[e]dit/[q]uit: ").strip().lower()
+        if cmd == "a":
+            task.test_suite = tests
+            return task
+        elif cmd == "r":
+            tests, explanation = await agent.generate_tests(task)
+            continue
+        elif cmd == "e":
+            tests = edit_func(tests)
+            continue
+        elif cmd == "q":
+            print("Aborted by user.")
+            return None
+        else:
+            print("Invalid command. Please enter a, r, e, or q.")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Prototype tasks on demand")
+    parser.add_argument("brief", nargs="?", help="Short problem description")
+    args = parser.parse_args()
+
+    brief = args.brief or input("Enter task brief: ")
+    logger.info("Brief provided: %s", brief)
+
+    task_id = f"prototype_{int(time.time())}"
+    task = TaskDefinition(id=task_id, description=brief)
+
+    result = await generate_and_confirm_tests(task)
+    if not result:
+        logger.info("User aborted before running evolution")
+        return
+
+    func_name = input("Function name to evolve [solve]: ").strip() or "solve"
+    imports_text = input("Allowed standard library imports (comma separated) [none]: ")
+    allowed_imports = [imp.strip() for imp in imports_text.split(",") if imp.strip()] if imports_text else []
+
+    result.function_name_to_evolve = func_name
+    result.allowed_imports = allowed_imports
+
+    logger.info("Starting TaskManagerAgent for task %s", task_id)
+    manager = TaskManagerAgent(task_definition=result)
+    best = await manager.execute()
+
+    if best:
+        best_program = best[0]
+        code_path = f"{task_id}_best.py"
+        with open(code_path, "w") as f:
+            f.write(best_program.code)
+        logger.info("Best program saved to %s", code_path)
+        print(f"Best program saved to {code_path}")
+    else:
+        logger.info("Evolution completed with no successful program")
+        print("No solution found.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_generator/agent.py
+++ b/test_generator/agent.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Optional, Dict, Any, Tuple
+
+from core.interfaces import BaseAgent, TaskDefinition
+
+logger = logging.getLogger(__name__)
+
+class TestGeneratorAgent(BaseAgent):
+    """Simple agent that generates tests for a task. Placeholder implementation."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        super().__init__(config)
+        logger.info("TestGeneratorAgent initialized")
+
+    async def generate_tests(self, task: TaskDefinition) -> Tuple[str, str]:
+        """Return a tuple of (tests_code, explanation)."""
+        function_name = task.function_name_to_evolve or "solve"
+        tests = (
+            f"def test_example():\n"
+            f"    assert {function_name}(1) == 1\n"
+        )
+        explanation = "Basic placeholder test suite generated."
+        return tests, explanation
+
+    async def execute(self, task: TaskDefinition) -> Tuple[str, str]:
+        return await self.generate_tests(task)

--- a/tests/test_prototype_on_demand.py
+++ b/tests/test_prototype_on_demand.py
@@ -1,0 +1,86 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from core.interfaces import TaskDefinition
+from prototype_on_demand import generate_and_confirm_tests
+
+
+class PrototypeLoopTests(unittest.TestCase):
+    def test_approve_first_try(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("tests1", "exp1")
+
+        inputs = iter(["a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertIs(result, task)
+        self.assertEqual(task.test_suite, "tests1")
+        mock_agent.generate_tests.assert_awaited_once()
+
+    def test_regenerate_then_approve(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.side_effect = [("t1", "e1"), ("t2", "e2")]
+
+        inputs = iter(["r", "a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertEqual(task.test_suite, "t2")
+        self.assertEqual(mock_agent.generate_tests.await_count, 2)
+        self.assertIs(result, task)
+
+    def test_edit_then_approve(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("t1", "e1")
+
+        inputs = iter(["e", "a"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: "edited",
+            )
+        )
+
+        self.assertEqual(task.test_suite, "edited")
+        self.assertIs(result, task)
+
+    def test_abort(self):
+        task = TaskDefinition(id="t", description="d")
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests.return_value = ("t1", "e1")
+
+        inputs = iter(["q"])
+        result = asyncio.run(
+            generate_and_confirm_tests(
+                task,
+                input_func=lambda _: next(inputs),
+                test_agent=mock_agent,
+                edit_func=lambda x: x,
+            )
+        )
+
+        self.assertIsNone(result)
+        self.assertIsNone(task.test_suite)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build CLI-based prototype with logging
- integrate interactive test loop
- save approved tests into `TaskDefinition`
- add placeholder dataclasses for test suites

## Testing
- `python -m unittest discover -s tests -v`
