### PR TITLE
Make dotenv import optional

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,7 +1,11 @@
 import os
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None
 
-load_dotenv()
+if load_dotenv:
+    load_dotenv()
 
 # LLM Configuration
 FLASH_API_KEY = os.getenv("FLASH_API_KEY")


### PR DESCRIPTION
## Summary
- make dotenv optional when settings are loaded

## Testing
- `pytest -q` *(fails: TestSuite.__init__() got an unexpected keyword argument 'files')*