### PR TITLE
Add UI unit test

### DIFF
--- a/prototype_on_demand_ui.py
+++ b/prototype_on_demand_ui.py
@@ -1,0 +1,36 @@
+import json
+from typing import List
+
+import gradio as gr
+
+from core.interfaces import TaskDefinition, TestSuite
+from test_generator.agent import TestGeneratorAgent
+from task_manager.agent import TaskManagerAgent
+
+
+async def generate_tests(brief: str, explanation_box: gr.Textbox, tests_box: gr.Textbox) -> TestSuite:
+    """Generate tests from a brief and update UI components."""
+    agent = TestGeneratorAgent()
+    suite = await agent.generate_tests(brief)
+    explanation_box.update(value=suite.explanation)
+    tests_box.update(value=json.dumps(suite.cases, indent=2))
+    return suite
+
+
+async def approve(
+    brief: str,
+    function_name: str,
+    allowed_imports: List[str],
+    suite: TestSuite,
+) -> TaskDefinition:
+    """Create a task definition and start the TaskManager."""
+    task = TaskDefinition(
+        id="prototype_task",
+        description=brief,
+        function_name_to_evolve=function_name,
+        input_output_examples=suite.cases,
+        allowed_imports=allowed_imports,
+    )
+    manager = TaskManagerAgent(task_definition=task)
+    await manager.execute()
+    return task

--- a/tests/test_prototype_on_demand_ui.py
+++ b/tests/test_prototype_on_demand_ui.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch, ANY
+
+unittest.importlib = __import__("importlib")  # type: ignore
+try:
+    ui = unittest.importlib.import_module("prototype_on_demand_ui")
+except Exception:  # pragma: no cover - module missing
+    ui = None
+
+from core.interfaces import TestSuite, TaskDefinition
+
+
+@unittest.skipIf(ui is None, "prototype_on_demand_ui module missing")
+class TestPrototypeOnDemandUI(unittest.IsolatedAsyncioTestCase):
+    async def test_generate_tests_updates_components(self):
+        suite = TestSuite(explanation="ok", cases=[{"input": [1], "output": 1}])
+        mock_agent = AsyncMock()
+        mock_agent.generate_tests = AsyncMock(return_value=suite)
+        with patch("prototype_on_demand_ui.TestGeneratorAgent", return_value=mock_agent):
+            expl_box = MagicMock(spec=ui.gr.Textbox)
+            tests_box = MagicMock(spec=ui.gr.Textbox)
+            expl_box.update = MagicMock()
+            tests_box.update = MagicMock()
+
+            result = await ui.generate_tests("brief", expl_box, tests_box)
+
+            self.assertIs(result, suite)
+            mock_agent.generate_tests.assert_awaited_once_with("brief")
+            expl_box.update.assert_called_once_with(value=suite.explanation)
+            tests_box.update.assert_called_once_with(value=ANY)
+
+    async def test_approve_invokes_task_manager(self):
+        suite = TestSuite(explanation="ok", cases=[{"input": [1], "output": 1}])
+        with patch("prototype_on_demand_ui.TaskManagerAgent") as manager_cls:
+            instance = manager_cls.return_value
+            instance.execute = AsyncMock(return_value=None)
+            task = await ui.approve("brief", "solve", ["os"], suite)
+
+            manager_cls.assert_called_once()
+            instance.execute.assert_awaited_once()
+            called_task = manager_cls.call_args.kwargs["task_definition"]
+            self.assertIsInstance(called_task, TaskDefinition)
+            self.assertEqual(called_task.description, "brief")
+            self.assertEqual(called_task.function_name_to_evolve, "solve")
+            self.assertEqual(called_task.allowed_imports, ["os"])
+            self.assertEqual(called_task.input_output_examples, suite.cases)
+            self.assertIs(task, called_task)


### PR DESCRIPTION
## Summary
- add `prototype_on_demand_ui` helpers for generating and approving prototype tasks
- test Gradio UI flow with mocks

## Testing
- `pytest -q`