### PR TITLE
Fix pytest collection warnings

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -19,6 +19,8 @@ class Program:
 @dataclass
 class TestSuite:
     """Container for test suite information used across agents."""
+    # Prevent pytest from mistakenly collecting this dataclass as a test case
+    __test__ = False
     # Mapping of filename to test contents when interacting with pytest
     files: Dict[str, str] = field(default_factory=dict)
     # Optional human readable explanation of the tests

--- a/test_generator/agent.py
+++ b/test_generator/agent.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 
 class TestGeneratorAgent(TestGeneratorInterface, BaseAgent):
     """Advanced agent that converts a natural-language brief into unit tests."""
+    # Prevent pytest from treating this agent as a test case
+    __test__ = False
 
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(config)
@@ -56,6 +58,3 @@ class TestGeneratorAgent(TestGeneratorInterface, BaseAgent):
         logger.info("Test suite generated with %d cases", len(cases))
         return suite
 
-    async def execute(self, brief: str) -> TestSuite:
-        """Entry point for BaseAgent: delegates to :meth:`generate_tests`."""
-        return await self.generate_tests(brief)


### PR DESCRIPTION
## Summary
- mark TestSuite dataclass to avoid pytest auto discovery
- remove duplicate execute method and mark TestGeneratorAgent

## Testing
- `pytest -q`