### PR TITLE
Enable pytest code generation and integrate with CLI

### DIFF
--- a/prototype_on_demand.py
+++ b/prototype_on_demand.py
@@ -53,6 +53,9 @@ async def generate_and_confirm_tests(agent: TestGeneratorAgent, brief: str):
         suite = await agent.generate_tests(brief)
         print("\n--- Test Explanation ---")
         print(suite.explanation)
+        if suite.tests_code:
+            print("\n--- Pytest Code ---")
+            print(suite.tests_code)
         print("\n--- Proposed Tests (JSON) ---")
         print(json.dumps({"explanation": suite.explanation, "cases": suite.cases}, indent=2))
         choice = input("[A]ccept / [R]egenerate / [E]dit / [Q]uit > ").strip().lower()
@@ -88,6 +91,9 @@ async def main():
     if not suite:
         return
 
+    if suite.tests_code:
+        suite.files = {"test_generated.py": suite.tests_code}
+
     func_name = args.func_name or input("Function name to evolve [solve]: ").strip() or "solve"
     imports_text = args.imports or input("Allowed standard library imports (comma separated) [none]: ")
     allowed_imports = [imp.strip() for imp in imports_text.split(",") if imp.strip()] if imports_text else []
@@ -99,6 +105,7 @@ async def main():
         function_name_to_evolve=func_name,
         input_output_examples=suite.cases,
         allowed_imports=allowed_imports,
+        test_suite=suite,
     )
 
     logger.info("Starting TaskManagerAgent for task %s", task_id)

--- a/test_generator/agent.py
+++ b/test_generator/agent.py
@@ -25,10 +25,11 @@ class TestGeneratorAgent(TestGeneratorInterface, BaseAgent):
         logger.info("Generating tests from brief")
 
         prompt = (
-            "You are a Python expert tasked with writing unit tests. "
-            "Given the problem description below, return a JSON object with two keys: "
-            "'explanation' summarizing your approach in English and 'cases' which is "
-            "a list of test case objects. Each test case must have 'input' and 'output' fields. "
+            "You are a Python expert tasked with writing pytest unit tests. "
+            "Given the problem description below, return a JSON object with the keys: "
+            "'explanation' summarizing your approach in English, 'cases' which is a list of "
+            "structured test case dictionaries, and 'tests_code' containing a complete pytest "
+            "test file. Each test case must have 'input' and 'output' fields. "
             "Only return valid JSON without markdown fences.\n\n"
             f"Problem Description:\n{brief}\n"
         )

--- a/tests/test_prototype_on_demand_cli.py
+++ b/tests/test_prototype_on_demand_cli.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+import sys
+
+import prototype_on_demand
+from core.interfaces import TestSuite, TaskDefinition
+
+class TestPrototypeOnDemandCLI(unittest.IsolatedAsyncioTestCase):
+    async def test_main_uses_pytest_suite(self):
+        suite = TestSuite(explanation="ok", cases=[], tests_code="assert True")
+        async_mock = AsyncMock(return_value=suite)
+        with patch('prototype_on_demand.generate_and_confirm_tests', async_mock), \
+             patch('prototype_on_demand.TestGeneratorAgent') as tg_cls, \
+             patch('prototype_on_demand.TaskManagerAgent') as manager_cls, \
+             patch.object(sys, 'argv', ['prog', 'brief', '-f', 'solve']), \
+             patch('builtins.input', return_value=''):
+            tg_cls.return_value = object()
+            manager_inst = manager_cls.return_value
+            manager_inst.execute = AsyncMock(return_value=None)
+            await prototype_on_demand.main()
+            manager_cls.assert_called_once()
+            called_task = manager_cls.call_args.kwargs['task_definition']
+            self.assertIsInstance(called_task, TaskDefinition)
+            self.assertEqual(called_task.test_suite.files['test_generated.py'], suite.tests_code)
+

--- a/tests/test_test_generator.py
+++ b/tests/test_test_generator.py
@@ -12,7 +12,8 @@ class DummyResponse:
 @pytest.mark.asyncio
 async def test_generate_tests_returns_llm_output():
     agent = TestGeneratorAgent()
-    dummy = DummyResponse("EXPECTED TESTS")
+    dummy_json = '{"explanation": "ok", "cases": [], "tests_code": "assert True"}'
+    dummy = DummyResponse(dummy_json)
     with patch("test_generator.agent.acompletion", new=AsyncMock(return_value=dummy)):
-        result = await agent.generate_tests("some code")
-    assert result == "EXPECTED TESTS"
+        suite = await agent.generate_tests("some code")
+    assert suite.tests_code.strip() == "assert True"

--- a/tests/test_test_generator_agent.py
+++ b/tests/test_test_generator_agent.py
@@ -9,11 +9,7 @@ class DummyResponse:
         self.choices = [SimpleNamespace(message=SimpleNamespace(content=content))]
 
 async def dummy_acompletion(*args, **kwargs):
-    return DummyResponse("""Some intro text
-```python
-assert True
-```
-This explains the tests.""")
+    return DummyResponse('{"explanation": "This explains the tests.", "cases": [], "tests_code": "assert True"}')
 
 class TestTestGeneratorAgent(unittest.IsolatedAsyncioTestCase):
     async def test_generate_tests_returns_suite(self):


### PR DESCRIPTION
## Summary
- instruct test generator to return pytest code in JSON
- show pytest code in CLI and store in `TestSuite.tests_code`
- have CLI create `TestSuite.files` for evaluation
- update unit tests for new behaviour and add CLI test

## Testing
- `pytest -q`